### PR TITLE
API Error Parsing

### DIFF
--- a/lib/mapbox.rb
+++ b/lib/mapbox.rb
@@ -105,7 +105,7 @@ module Mapbox
   def self.handle_api_error(rcode, rbody)
     begin
       error = JSON.parse(rbody)
-      raise StandardError.new if !error.has_key?("message") # escape from parsing
+      raise StandardError.new unless error.has_key?("message") # escape from parsing
 
     rescue JSON::ParserError, StandardError
       raise general_api_error(rcode, rbody)


### PR DESCRIPTION
This is a fix for #42 Error Granularity. Exceptions raised by the API will be returned with the correct message provided by the Mapbox API, such as:
`API Error: 422 Unprocessable Entity - Query too long - 273/256 characters`

fix: correct api error message parsing
fix: raise exceptions with formatted string

Ran the test suite locally, with
```
24 tests, 29 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
